### PR TITLE
CP-14028: Update networkd_db program to output vlan config.

### DIFF
--- a/networkd_db/networkd_db.ml
+++ b/networkd_db/networkd_db.ml
@@ -43,7 +43,11 @@ let _ =
 			if List.mem_assoc !bridge config.bridge_config then begin
 				let bridge_config = List.assoc !bridge config.bridge_config in
 				let ifaces = List.flatten (List.map (fun (_, port) -> port.interfaces) bridge_config.ports) in
-				Printf.printf "interfaces=%s\n" (String.concat "," ifaces)
+				Printf.printf "interfaces=%s\n" (String.concat "," ifaces);
+				begin match bridge_config.vlan with
+					| None -> ()
+					| Some (parent, id) -> Printf.printf "vlan=%d\nparent=%s\n" id parent
+				end
 			end else begin
 				rc := 1;
 				Printf.fprintf stderr "Could not find bridge %s\n" !bridge;


### PR DESCRIPTION
networkd_db must provide interfaces, vlan tag and parent bridge
details when asked for bridge_config for a vlan bridge.

Signed-off-by: Sharad Yadav <sharad.yadav@citrix.com>