### PR TITLE
CA-242016: Fix read_management_conf for management vlan config.

### DIFF
--- a/lib/network_config.ml
+++ b/lib/network_config.ml
@@ -33,6 +33,7 @@ let read_management_conf () =
 		let args = List.map (fun s -> match (String.split '=' s) with k :: [v] -> k, String.strip ((=) '\'') v | _ -> "", "") args in
 		debug "Firstboot file management.conf has: %s" (String.concat "; " (List.map (fun (k, v) -> k ^ "=" ^ v) args));
 		let device = List.assoc "LABEL" args in
+		let vlan = if List.mem_assoc "VLAN" args then List.assoc "VLAN" args else "" in
 		Inventory.reread_inventory ();
 		let bridge_name = Inventory.lookup Inventory._management_interface in
 		debug "Management bridge in inventory file: %s" bridge_name;
@@ -64,13 +65,27 @@ let read_management_conf () =
 		in
 		let phy_interface = {default_interface with persistent_i = true} in
 		let bridge_interface = {default_interface with ipv4_conf; ipv4_gateway; persistent_i = true} in
-		let bridge = {default_bridge with
-			bridge_mac = Some mac;
-			ports = [device, {default_port with interfaces = [device]}];
-			persistent_b = true
-		} in
-		{interface_config = [device, phy_interface; bridge_name, bridge_interface];
-			bridge_config = [bridge_name, bridge];
+		let interface_config, bridge_config =
+			let primary_bridge_conf = {default_bridge with
+                        	bridge_mac = Some mac;
+	                        ports = [device, {default_port with interfaces = [device]}];
+        	                persistent_b = true
+                	} in
+			if vlan <> "" && not (String.startswith "xenbr" bridge_name) && bridge_name <> "" then begin
+				let parent = "xenbr" ^ (String.sub device 3 (String.length device - 3)) in
+				let secondary_bridge_conf = {default_bridge with
+					vlan = Some (parent, int_of_string vlan);
+					bridge_mac = (Some mac);
+					persistent_b = true
+				} in
+				[device, phy_interface; parent, phy_interface; bridge_name, bridge_interface],
+				[parent, primary_bridge_conf; bridge_name, secondary_bridge_conf]
+			end
+			else
+				[device, phy_interface; bridge_name, bridge_interface],
+				[bridge_name, primary_bridge_conf]
+		in
+		{interface_config = interface_config; bridge_config = bridge_config;
 			gateway_interface = Some bridge_name; dns_interface = Some bridge_name}
 	with e ->
 		error "Error while trying to read firstboot data: %s\n%s"


### PR DESCRIPTION
`xe-reset-networking` for management vlan config performed on slave
will write the management bridge of Pool master into inventory of slave.
If VLAN tag and management bridge is of vlan then xcp-networkd must
create the management bridge with vlan config.

Signed-off-by: Sharad Yadav <sharad.yadav@citrix.com>