### PR TITLE
CA-242016: Fix read_management_conf for management vlan config.

### DIFF
--- a/lib/network_config.ml
+++ b/lib/network_config.ml
@@ -26,6 +26,11 @@ exception Write_error
 
 let config_file_path = "/var/lib/xcp/networkd.db"
 
+let bridge_naming_convention (device: string) =
+	if String.startswith "eth" device
+		then ("xenbr" ^ (String.sub device 3 (String.length device - 3)))
+	else ("br" ^ device)
+
 let read_management_conf () =
 	try
 		let management_conf = Unixext.string_of_file ("/etc/firstboot.d/data/management.conf") in

--- a/networkd/network_server.ml
+++ b/networkd/network_server.ml
@@ -474,12 +474,56 @@ module Bridge = struct
 			| Bridge -> Sysfs.get_all_bridges ()
 		) ()
 
+	let destroy_existing_vlan_bridge name (parent, vlan) =
+		begin match !backend_kind with
+		| Openvswitch ->
+			let bridges =
+				let raw = Ovs.vsctl ["--bare"; "-f"; "table"; "--"; "--columns=name"; "find"; "port"; "fake_bridge=true"; "tag=" ^ (string_of_int vlan)] in
+				if raw <> "" then String.split '\n' (String.rtrim raw) else []
+			in
+			let existing_bridges =
+				List.filter ( fun bridge ->
+					match Ovs.bridge_to_vlan bridge with
+					| Some (p, v) -> p = parent && v = vlan
+					| None -> false
+				) bridges in
+			List.iter (fun bridge ->
+				if bridge <> name then begin
+					debug "Destroying existing bridge %s" bridge;
+					remove_config bridge;
+					ignore (Ovs.destroy_bridge bridge)
+				end
+			) existing_bridges
+		| Bridge ->
+			let ifaces = Sysfs.bridge_to_interfaces parent in
+			let existing_bridges =
+				match List.filter (fun (_, tag, iface) -> tag = vlan && List.mem iface ifaces) (Proc.get_vlans ()) with
+				| [] -> []
+				| (vlan_iface, _, _) :: _ ->
+					List.filter (fun bridge ->
+						List.mem vlan_iface (Sysfs.bridge_to_interfaces bridge)
+					) (Sysfs.get_all_bridges ())
+			in
+			List.iter (fun bridge ->
+				if bridge <> name then begin
+					debug "Destroying existing bridge %s" bridge;
+					Interface.bring_down () "Destroying existing bridge" ~name:bridge;
+					remove_config bridge;
+					List.iter (fun dev ->
+						Brctl.destroy_port bridge dev;
+					) (Sysfs.bridge_to_interfaces bridge);
+					ignore (Brctl.destroy_bridge bridge)
+				end
+			) existing_bridges
+		end
+
 	let create _ dbg ?vlan ?mac ?(other_config=[]) ~name () =
 		Debug.with_thread_associated dbg (fun () ->
 			debug "Creating bridge %s%s" name (match vlan with
 				| None -> ""
 				| Some (parent, vlan) -> Printf.sprintf " (VLAN %d on bridge %s)" vlan parent
 			);
+			Stdext.Opt.iter (destroy_existing_vlan_bridge name) vlan;
 			update_config name {(get_config name) with vlan; bridge_mac=mac; other_config};
 			begin match !backend_kind with
 			| Openvswitch ->


### PR DESCRIPTION
`xe-reset-networking` for management vlan config will write a
temporary vlan bridge into inventory.
If management conf has VLAN tag then xcp-networkd must
create the management bridge with vlan config.

Signed-off-by: Sharad Yadav <sharad.yadav@citrix.com>