### PR TITLE
CA-237543: Fix vlan bridge ipv4 conf on destroying parent bridge.

### DIFF
--- a/networkd/network_server.ml
+++ b/networkd/network_server.ml
@@ -622,13 +622,15 @@ module Bridge = struct
 			Interface.bring_down () dbg ~name;
 			match !backend_kind with
 			| Openvswitch ->
-				if Ovs.get_vlans name = [] || force then begin
+				let vlans_on_this_parent = Ovs.get_vlans name in
+				if vlans_on_this_parent = [] || force then begin
 					debug "Destroying bridge %s" name;
 					remove_config name;
+					let interfaces = (Ovs.bridge_to_interfaces name) @ vlans_on_this_parent in
 					List.iter (fun dev ->
 						Interface.set_ipv4_conf () dbg ~name:dev ~conf:None4;
 						Interface.bring_down () dbg ~name:dev
-					) (Ovs.bridge_to_interfaces name);
+					) interfaces;
 					Interface.set_ipv4_conf () dbg ~name ~conf:None4;
 					ignore (Ovs.destroy_bridge name)
 				end else


### PR DESCRIPTION
On destroying parent bridge of vlan during bond.create:
1) Doesn't set ipv4 conf for vlan bridge to None.
2) Vlan bridge gets destroyed automatically without stopping dhclient.

It triggers, non starting of dhclient while recreating same vlan bridge
on top of bond bridge.

Call `Interface.bring_down` and `Interface.set_ipv4_conf` to None
for all vlan bridges.

Signed-off-by: Sharad Yadav <sharad.yadav@citrix.com>